### PR TITLE
update tunnel dependency for late node js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "lodash": "1.3.1",
-    "tunnel": "0.0.2"
+    "tunnel": "0.0.4"
   },
   "devDependencies": {
     "mocha": "1.16.2",


### PR DESCRIPTION
see title, simple dependency upgrade

If not merged or no communication the date when hardfork occurs is going to be 01 July 2016